### PR TITLE
Wmwv/fix date high sierra

### DIFF
--- a/messages-exporter.php
+++ b/messages-exporter.php
@@ -49,6 +49,17 @@ if ( ! file_exists( $options['o'] ) ) {
 	mkdir( $options['o'] );
 }
 
+# Prior to Mac OS X High Sierra  (10.13), time in 'chat.db' was in seconds
+# Starting with High Sierra time in 'chat.db' is in nanoseconds
+# Mac OS X High Sierra started the Darwin 17 major version
+# We assume that all Darwin >= 17 uses the same nanosecond convention
+$time_to_seconds = 1
+$darwin_release = php_uname('r')
+$darwin_nanosecond_release = 17
+if ( $darwin_release >= $darwin_nanosecond_release ){
+	$time_to_seconds = 1E-09;
+}
+
 $database_file = $options['o'] . 'messages-exporter.db';
 
 if ( ! isset( $options['r'] ) ) {
@@ -95,7 +106,7 @@ if ( ! isset( $options['r'] ) ) {
 			"SELECT
 				message.ROWID,
 				message.is_from_me,
-				datetime(message.date + strftime('%s', '2001-01-01 00:00:00'), 'unixepoch', 'localtime') as date,
+				datetime(message.date*time_to_seconds + strftime('%s', '2001-01-01 00:00:00'), 'unixepoch', 'localtime') as date,
 				message.text,
 				handle.id as contact,
 				message.cache_has_attachments

--- a/messages-exporter.php
+++ b/messages-exporter.php
@@ -112,7 +112,7 @@ if ( ! isset( $options['r'] ) ) {
 			"SELECT
 				message.ROWID,
 				message.is_from_me,
-				datetime(message.date*time_to_seconds +
+				datetime(message.date*:time_to_seconds +
 					strftime('%s', '2001-01-01 00:00:00'),
 					'unixepoch',
 					'localtime') as date,
@@ -122,6 +122,7 @@ if ( ! isset( $options['r'] ) ) {
 			FROM message LEFT JOIN handle ON message.handle_id=handle.ROWID
 			WHERE message.ROWID IN (SELECT message_id FROM chat_message_join WHERE chat_id=:rowid)" );
 		$statement->bindValue( ':rowid', $row['ROWID'] );
+		$statement->bindValue( ':time_to_seconds', $time_to_seconds );
 	
 		$messages = $statement->execute();
 	

--- a/messages-exporter.php
+++ b/messages-exporter.php
@@ -53,9 +53,9 @@ if ( ! file_exists( $options['o'] ) ) {
 # Starting with High Sierra time in 'chat.db' is in nanoseconds
 # Mac OS X High Sierra started the Darwin 17 major version
 # We assume that all Darwin >= 17 uses the same nanosecond convention
-$time_to_seconds = 1
-$darwin_release = php_uname('r')
-$darwin_nanosecond_release = 17
+$time_to_seconds = 1;
+$darwin_release = php_uname('r');
+$darwin_nanosecond_release = 17;
 if ( $darwin_release >= $darwin_nanosecond_release ){
 	$time_to_seconds = 1E-09;
 }

--- a/messages-exporter.php
+++ b/messages-exporter.php
@@ -102,11 +102,20 @@ if ( ! isset( $options['r'] ) ) {
 			$chat_title = $contactNumber;
 		}
 
+		# chat.db records the datetime in [nano]seconds
+		#    since 2001-01-01 00:00:00 UTC
+		# Add this reference base time in unixepoch seconds to message.date
+		#    strftime('%s', ...) returns in unixepoch seconds
+		# The use datetime(...) to convert from unixepoch to localtime
+		#  YYYY-MM-DD HH:MM:SS
 		$statement = $db->prepare(
 			"SELECT
 				message.ROWID,
 				message.is_from_me,
-				datetime(message.date*time_to_seconds + strftime('%s', '2001-01-01 00:00:00'), 'unixepoch', 'localtime') as date,
+				datetime(message.date*time_to_seconds +
+					strftime('%s', '2001-01-01 00:00:00'),
+					'unixepoch',
+					'localtime') as date,
 				message.text,
 				handle.id as contact,
 				message.cache_has_attachments


### PR DESCRIPTION
Fix for #1 

1. Identify High Sierra Mac OS X by looking for Darwin release >= 17
2. If High Sierra, then interpret time in nanoseconds.  Otherwise interpret in seconds, as before.